### PR TITLE
loosen up things in css

### DIFF
--- a/src/app/lib/datatable/datatable.ts
+++ b/src/app/lib/datatable/datatable.ts
@@ -40,15 +40,12 @@ import {MomentumTemplate} from './template.directive';
   `,
   styles: [`
     .card-wrapper{
-      padding: 0px !important;
+      padding: 0;
     }
     .table-container{
-      width: 100%;
-      overflow: scroll;
+      overflow: auto;
       background: #fff;
-      display: inline-block !important;
-      font-family: Roboto,Helvetica Neue,sans-serif !important;
-      font-size: 14px;
+      font-family: Roboto, 'Helvetica Neue', sans-serif;
       color: rgba(0, 0, 0, 0.87);
     }
     table {

--- a/src/app/lib/datatable/datatable.ts
+++ b/src/app/lib/datatable/datatable.ts
@@ -45,7 +45,6 @@ import {MomentumTemplate} from './template.directive';
     .table-container{
       overflow: auto;
       background: #fff;
-      font-family: Roboto, 'Helvetica Neue', sans-serif;
       color: rgba(0, 0, 0, 0.87);
     }
     table {


### PR DESCRIPTION
...so implementors of the table can override things when they want.

- removed the `font-size` declaration because the table already uses `mat-body-1` font and that can be configured by the user. setting it in here makes it hard to theme the table.
- no need to set the table-container to `display: inline-block !important` and then also set it's width to 100%. It's a div, so it's block by default.
- I also feel that the table shouldn't create a card all by itself. Let people create the table and put in whatever container they want and override things there. But that's another issue.
- removing `!important` from `font-family` declaration so it can be overridden via theme. If you need to test this while developing the table, set the font-family on the app or let material load it's default font anyway.